### PR TITLE
修复 颜色值转16进制后拼接"#", 16进制零打头导致的位数不足

### DIFF
--- a/src/APG/Target.js
+++ b/src/APG/Target.js
@@ -95,7 +95,7 @@ APG.Target.loadTextBitMap = function(sprite, text, bgColor, fontColor, fontAlpha
         sprite.loadTexture(bmd);
     }
 
-    let textColor = '#'+parseInt(color).toString(16);
+    let textColor = '#'+("000000"+parseInt(color).toString(16)).slice(-6);
     if(fontAlpha){
         textColor += parseInt(0x100 * fontAlpha).toString(16)
     }


### PR DESCRIPTION
标题：
已完成的工作：
